### PR TITLE
Update rini.h (https://github.com/raysan5/rini/issues/3)

### DIFF
--- a/src/rini.h
+++ b/src/rini.h
@@ -495,7 +495,7 @@ static int rini_read_config_key(const char *buffer, char *key)
 // Get config string-value from a buffer line containing id-value pair
 static int rini_read_config_value_text(const char *buffer, char *text, char *desc)
 {
-    char *buffer_ptr = buffer;
+    const char *buffer_ptr = buffer;
 
     // Expected config line structure:
     // [key][spaces?][delimiter?][spaces?]["?][textValue]["?][spaces?][[;][#]description?]


### PR DESCRIPTION
Made line 498 `const` to fix `const` conversion error in C++.

Since `const char* buffer` is `const` in the parameter list, making a mutable pointer to `buffer` is illegal; however, with `buffer_ptr` not evidently being modified it should be able to be made `const` and forgotten about.