### PR TITLE
Fix rini_set_value incorrectly handles the is_text flag

### DIFF
--- a/src/rini.h
+++ b/src/rini.h
@@ -782,8 +782,14 @@ int rini_set_value(rini_data *data, const char *key, int value, const char *desc
 
     result = rini_set_value_text(data, key, value_text, desc);
 
-    data->values[data->count - 1].is_text = false;
-
+    if(result == 0){
+        for (unsigned int i = 0; i < data->count; i++){
+            if (strcmp(key, data->values[i].key) == 0){  // Key found
+                data->values[i].is_text = false;
+                break;
+            }   
+        }
+    }
     return result;
 }
 


### PR DESCRIPTION
When using this library, I discovered that `rini_set_value` may incorrectly set the `is_text` flag because the key may have already existed, so its index is not equal to `data->count - 1`.

**In the function:** 
```C
// Set value and description for existing key or create a new entry
int rini_set_value(rini_data *data, const char *key, int value, const char *desc)
{
    int result = -1;
    char value_text[RINI_MAX_TEXT_SIZE] = { 0 };

    snprintf(value_text, RINI_MAX_TEXT_SIZE, "%i", value);

    result = rini_set_value_text(data, key, value_text, desc);

    data->values[data->count - 1].is_text = false;
    
    return result;
}
```


### Use this code to reproduce.
```C
#define RINI_IMPLEMENTATION
#include <stdbool.h>  
#include <stdlib.h>
#include "src/rini.h"
#include <stdio.h>

int main(void)
{
    printf("\n=== Test : rini_set_value incorrectly handles the is_text flag when updating an existing key. ===\n");

    rini_data config  = rini_load(NULL);
    // First, add a text type value.
    rini_set_value_text(&config , "key1", "hello", NULL);
    // Add another text value.
    rini_set_value_text(&config , "key2", "world", NULL);
    // Update the first key
    rini_set_value(&config , "key1", 99, "updated");

    printf("  values[0] (key1): text=%s, is_text=%d  <-- Should be false (int).\n",
           config .values[0].text, config .values[0].is_text);
    printf("  values[1] (key1): text=%s, is_text=%d  <-- Should be true (text)\n",
           config .values[1].text, config .values[1].is_text);

    // Check the output.ini
    printf("\nSaving to test_output.ini ...\n");
    rini_save(config , "test_output.ini");
    rini_unload(&config );
    return 0;
}

```