### PR TITLE
Keep save_to_memory output contiguous after truncation

### DIFF
--- a/src/rini.h
+++ b/src/rini.h
@@ -680,7 +680,7 @@ char *rini_save_to_memory(rini_data data)
             }
         }
         
-        if (expectedByteWritten >= RINI_MAX_LINE_SIZE) offset += RINI_MAX_LINE_SIZE;
+        if ((expectedByteWritten < 0) || (expectedByteWritten >= RINI_MAX_LINE_SIZE)) offset += (int)strlen(text + offset);
         else offset += expectedByteWritten;
     }
 


### PR DESCRIPTION
Keep `rini_save_to_memory()` output contiguous when a line is truncated

`rini_save_to_memory()` formats each entry with `snprintf()` and then advances an output offset. The previous code assumed every truncating implementation would return a value at least as large as `RINI_MAX_LINE_SIZE`. On MinGW, `snprintf()` returns `-1` for this case, so the offset was advanced incorrectly and later entries could disappear from the returned text.

The offset now advances by the number of bytes actually present in the current output segment whenever the return value indicates truncation. Short, non-truncated writes continue to use the returned length.

Validation:

- MinGW GCC 8.1 baseline/fixed comparison with a maximum-sized key, value, description, and a following `tail` entry: baseline omits `tail`; fixed output retains it.
- WSL GCC 13 baseline/fixed comparison: same behavioral difference.
- Linux GCC 13 with AddressSanitizer and UndefinedBehaviorSanitizer: fixed case passes.
- `-Wall -Wextra -Werror` compilation and `git diff --check` pass.
